### PR TITLE
license: Correct license to GPLv2+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     },
     author='Shaun McCance',
     author_email='shaunm@gnome.org',
-    license='MIT',
+    license='GPLv2+',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',


### PR DESCRIPTION
As we discussed, displaying MIT as the license is a typo, and GPLv2+ is the intended license.
