### PR TITLE
FSF address correction

### DIFF
--- a/pintail/__init__.py
+++ b/pintail/__init__.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; see the file COPYING.LGPL.  If not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+# Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02111-1307, USA.
 
 __import__('pkg_resources').declare_namespace(__name__)

--- a/pintail/docbook.py
+++ b/pintail/docbook.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; see the file COPYING.LGPL.  If not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+# Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02111-1307, USA.
 
 import os

--- a/pintail/git.py
+++ b/pintail/git.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; see the file COPYING.LGPL.  If not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+# Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02111-1307, USA.
 
 import os

--- a/pintail/pintail-atom.xsl
+++ b/pintail/pintail-atom.xsl
@@ -12,7 +12,7 @@ details.
 
 You should have received a copy of the GNU Lesser General Public License
 along with this program; see the file COPYING.LGPL.  If not, write to the
-Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 02111-1307, USA.
 -->
 

--- a/pintail/pintail-html.xsl
+++ b/pintail/pintail-html.xsl
@@ -12,7 +12,7 @@ details.
 
 You should have received a copy of the GNU Lesser General Public License
 along with this program; see the file COPYING.LGPL.  If not, write to the
-Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 02111-1307, USA.
 -->
 

--- a/pintail/search.py
+++ b/pintail/search.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; see the file COPYING.LGPL.  If not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+# Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02111-1307, USA.
 
 import pintail.site

--- a/pintail/site.py
+++ b/pintail/site.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; see the file COPYING.LGPL.  If not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+# Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02111-1307, USA.
 
 import codecs


### PR DESCRIPTION
While doing a package review for Fedora it was pointed out that the FSF address is source files was not correct. Please accept this almost completely useless PR.
