### PR TITLE
Refactor directories to allow multiple sources

### DIFF
--- a/pintail/docbook.py
+++ b/pintail/docbook.py
@@ -1,5 +1,5 @@
 # pintail - Build static sites from collections of Mallard documents
-# Copyright (c) 2015 Shaun McCance <shaunm@gnome.org>
+# Copyright (c) 2015-2020 Shaun McCance <shaunm@gnome.org>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -39,16 +39,25 @@ DOCBOOK_INFOS = [
     'referenceinfo', 'sect1info', 'sect2info', 'sect3info', 'sect4info', 'sect5info',
     'sectioninfo', 'setindexinfo']
 
-class DocBookPage(pintail.site.Page, pintail.site.ToolsProvider, pintail.site.CssProvider):
+class DocBookPage(pintail.site.Page):
+    """
+    The primary page in a DocBook document.
+
+    A DocBook document can create multiple output files. There is exaclty one
+    `DocBookPage` object for each document. It can then have any number of
+    `DocBookSubPage` objects, which are stored in `subpages`. The primary page
+    does most of the work, including building all HTML, but the subpages exist
+    for tracking and search purposes.
+    """
 
     _html_transform = None
 
-    def __init__(self, directory, source_file):
+    def __init__(self, source, filename):
         self.pbdoctype = None
         self.pbbrand = None
         self.pblang = None
 
-        pintail.site.Page.__init__(self, directory, source_file)
+        super().__init__(source, filename)
         self.stage_page()
         self._tree = etree.parse(self.get_stage_path())
         maxdepth = 1
@@ -99,6 +108,7 @@ class DocBookPage(pintail.site.Page, pintail.site.ToolsProvider, pintail.site.Cs
         self._langtrees = {}
         self._notlangs = set()
 
+
     def _get_tree(self, lang=None):
         if lang is None or lang in self._notlangs:
             return self._tree
@@ -110,15 +120,33 @@ class DocBookPage(pintail.site.Page, pintail.site.ToolsProvider, pintail.site.Cs
         self._notlangs.add(lang)
         return self._tree
 
+
     @property
     def page_id(self):
+        """
+        The simple id of the page.
+
+        This is always `"index"` for the primary page of a DocBook document,
+        regardless of the file name or the value of the `id` attribute.
+        """
         return 'index'
+
 
     @property
     def searchable(self):
+        """
+        Whether the page should be added to the search index.
+        """
         return True
 
+
     def get_title_node(self, node, hint=None):
+        """
+        Get the title for a node in the DocBook tree.
+
+        This is a utility function to share the `get_title` code between
+        `DocBookPage` and `DocBookSubPage`.
+        """
         title = ''
         for child in node:
             if child.tag in DOCBOOK_INFOS:
@@ -130,10 +158,24 @@ class DocBookPage(pintail.site.Page, pintail.site.ToolsProvider, pintail.site.Cs
                 break
         return title
 
+
     def get_title(self, hint=None, lang=None):
+        """
+        Get the title of the DocBook page.
+
+        This implementation prefers the `title` element in the `info` (or similar)
+        element, but will use the primary display title if an info title is not found.
+        """
         return self.get_title_node(self._get_tree(lang).getroot(), hint=hint)
 
+
     def get_keywords_node(self, node, hint=None):
+        """
+        Get the keywords for a node in the DocBook tree.
+
+        This is a utility function to share the `get_keywords` code between
+        `DocBookPage` and `DocBookSubPage`.
+        """
         keywords = ''
         for child in node:
             if child.tag in DOCBOOK_INFOS:
@@ -147,10 +189,24 @@ class DocBookPage(pintail.site.Page, pintail.site.ToolsProvider, pintail.site.Cs
                 break
         return keywords
 
+
     def get_keywords(self, hint=None, lang=None):
+        """
+        Get the keywords of the DocBook page.
+
+        This implementation looks at the `keywordset` element. It makes a
+        comma-separated list from each `keyword` child element.
+        """
         return self.get_keywords_node(self._get_tree(lang).getroot(), hint=hint)
 
+
     def get_content_node(self, node, hint=None):
+        """
+        Get the content for a node in the DocBook tree.
+
+        This is a utility function to share the `get_content` code between
+        `DocBookPage` and `DocBookSubPage`.
+        """
         depth = 0
         parent = node.getparent()
         while parent is not None:
@@ -171,11 +227,388 @@ class DocBookPage(pintail.site.Page, pintail.site.ToolsProvider, pintail.site.Cs
             return ret
         return _accumulate_text(node)
 
+
     def get_content(self, hint=None, lang=None):
+        """
+        Get the full content of the DocBook page.
+
+        This implementation tries carefully not to include content from
+        subpages in the content for this page.
+        """
         return self.get_content_node(self._get_tree(lang).getroot(), hint=hint)
+
+
+    def _rewrite_publican_xml_file(self, source, target, entfile):
+        p = subprocess.Popen(['xmllint', '--dropdtd', source],
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        lines = p.communicate()[0].decode('utf-8').split('\n')
+        decl = None
+        if lines[0].startswith('<?xml'):
+            decl = lines.pop(0)
+        el = None
+        for line in lines:
+            if '<' in line:
+                el = line[line.index('<')+1:]
+                if el[0] != '!':
+                    if ' ' in el:
+                        el = el[:el.index(' ')]
+                    elif '>' in el:
+                        el = el[:el.index('>')]
+                    break
+        doctype = '<!DOCTYPE %s PUBLIC ' % el
+        if self.pbdoctype.startswith('4.'):
+            doctype += '"-//OASIS//DTD DocBook XML V%s//EN" ' % self.pbdoctype
+            doctype += '"http://www.oasis-open.org/docbook/xml/%s/docbookx.dtd" [\n' % self.pbdoctype
+        elif self.pbdoctype.startswith('5.'):
+            FIXME
+        else:
+            FIXME
+        if entfile is not None:
+            doctype += '<!ENTITY %% BOOK_ENTITIES SYSTEM "%s">\n' % entfile
+            doctype += '%BOOK_ENTITIES;\n'
+        doctype += ']>\n'
+        fd = open(target, 'w')
+        if decl is not None:
+            fd.write(decl + '\n')
+        fd.write(doctype)
+        for line in lines:
+            fd.write(line + '\n')
+        fd.close()
+
+
+    def _stage_page_publican(self):
+        # Publican does some weird things to DocBook, including rewriting the DOCTYPE
+        # in a way that lets you write non-well-formed XML that can't be read by any
+        # other tool. Pintail can pretend to be Publican.
+        pbdir = os.path.join(self.directory.get_stage_path(), '__publican__')
+        pintail.site.Site._makedirs(pbdir)
+
+        # Look for the publican.cfg file and extract some values from it.
+        cfgdir = self.source.get_source_path()
+        cfg = os.path.join(cfgdir, 'publican.cfg')
+        while not os.path.exists(cfg):
+            if os.path.dirname(cfgdir) == cfgdir:
+                break
+            cfgdir = os.path.dirname(cfgdir)
+            cfg = os.path.join(cfgdir, 'publican.cfg')
+        if os.path.exists(cfg):
+            for line in open(cfg):
+                if line.startswith('brand:'):
+                    self.pbbrand = line[line.index(':')+1:].strip()
+                if line.startswith('xml_lang:'):
+                    self.pblang = line[line.index(':')+1:].strip()
+
+        # Rewrite the DOCTYPE of all .xml files, using a .ent file with the
+        # same basename if available. This is the craziness Publican does.
+        xmlfiles = []
+        entfile = None
+        dpath = self.source.get_source_path()
+        for xml in os.listdir(dpath):
+            if not os.path.isfile(os.path.join(dpath, xml)):
+                continue
+            if xml.endswith('.xml'):
+                xmlfiles.append(xml)
+            elif xml == os.path.splitext(self.source_file)[0] + '.ent':
+                entfile = xml
+                shutil.copyfile(os.path.join(dpath, entfile), os.path.join(pbdir, entfile))
+        for xml in xmlfiles:
+            self._rewrite_publican_xml_file(os.path.join(dpath, xml),
+                                            os.path.join(pbdir, xml),
+                                            entfile)
+
+        # Publican also ships "common content", some of which is required
+        # for parsing. But even the common content has to be rewritten to
+        # reference the .ent file in your repo. We can only do this if we
+        # found a brand and language in publican.cfg.
+        if self.pbbrand is not None and self.pblang is not None:
+            ccdir = os.path.join(pbdir, 'Common_Content')
+            pintail.site.Site._makedirs(ccdir)
+            branddir = os.path.join('/usr/share/publican/Common_Content/', self.pbbrand, self.pblang)
+            commondir = os.path.join('/usr/share/publican/Common_Content/common/', self.pblang)
+            brandfiles = [os.path.join(branddir, xml) for xml in os.listdir(branddir)]
+            commonfiles = [os.path.join(commondir, xml) for xml in os.listdir(commondir)]
+            donefiles = set()
+            for filename in brandfiles + commonfiles:
+                bname = os.path.basename(filename)
+                if bname in donefiles:
+                    continue
+                if not os.path.isfile(filename):
+                    continue
+                if filename.endswith('.xml'):
+                    donefiles.add(bname)
+                    self._rewrite_publican_xml_file(filename,
+                                                    os.path.join(ccdir, bname),
+                                                    '../' + entfile)
+
+        # Finally, make a baked XML file in the location the rest of Pintail expects.
+        subprocess.call(['xmllint', '--xinclude', '--noent', '--loaddtd',
+                         '-o', self.get_stage_path(),
+                         os.path.join(pbdir, self.source_file)])
+
+
+    def stage_page(self):
+        """
+        Create a DocBook file in the stage.
+
+        This implementation adds the entire DocBook document to the stage,
+        including all content needed by subpages.
+        If the document has been marked as a Publican document with the
+        `publican_doctype` config option, this method will do various
+        things to the document to try to emulate Publican.
+        """
+        pintail.site.Site._makedirs(self.directory.get_stage_path())
+        self.pbdoctype = self.site.config.get('publican_doctype', self.source.name)
+        if self.pbdoctype is not None:
+            self._stage_page_publican()
+        else:
+            subprocess.call(['xmllint', '--xinclude', '--noent',
+                             '-o', self.get_stage_path(),
+                             self.get_source_path()])
+
+
+    def get_cache_data(self, lang=None):
+        """
+        Get XML data to add to the cache, as an lxml.etree.Element object.
+
+        The DocBook cache data is in a `pintail:external` element.
+        """
+        ret = None
+        try:
+            ret = etree.Element(PINTAIL_NS + 'external')
+            ret.set('id', self.directory.path + 'index')
+            ret.set(SITE_NS + 'dir', self.directory.path)
+            dbfile = self._get_tree(lang)
+            dbfile.xinclude()
+            info = None
+            title = None
+            for child in dbfile.getroot():
+                if not isinstance(child.tag, str):
+                    continue
+                if child.tag == (DOCBOOK_NS + 'info'):
+                    info = child
+                elif etree.QName(child.tag).namespace is None and child.tag.endswith('info'):
+                    info = child
+                elif child.tag in ('title', DOCBOOK_NS + 'title'):
+                    title = child
+                    break
+            if title is None and info is not None:
+                for child in info:
+                    if child.tag in ('title', DOCBOOK_NS + 'title'):
+                        title = child
+                        break
+            if title is not None:
+                title = title.xpath('string(.)')
+                titlen = etree.Element(MAL_NS + 'title')
+                titlen.text = title
+                ret.append(titlen)
+        except:
+            pass
+        return ret
+
+
+    def build_html(self, lang=None):
+        """
+        Build the HTML file for the entire DocBook document, possibly translated.
+
+        This implementation generates all HTML files for all pages in the document,
+        including all subpages. `DocBookSubPage` does not implement `build_html`.
+        """
+        if lang is None:
+            self.site.log('HTML', self.site_id)
+        else:
+            self.site.log('HTML', lang + ' ' + self.site_id)
+
+        if DocBookPage._html_transform is None:
+            DocBookPage._html_transform = etree.XSLT(etree.parse(os.path.join(self.site.tools_path,
+                                                                              'pintail-html-docbook-local.xsl')))
+        args = {}
+        args['pintail.format'] = etree.XSLT.strparam('docbook')
+        for pair in pintail.site.XslProvider.get_all_xsl_params('html', self, lang=lang):
+            args[pair[0]] = etree.XSLT.strparam(pair[1])
+        tree = self._get_tree(lang)
+        DocBookPage._html_transform(tree, **args)
+
+        return
+        # Leaving in this code to call xsltproc for now. It turns out that using
+        # etree.XSLT is slower on each individual run than calling xsltproc, oddly
+        # enough. But it gets you performance gains over large numbers of documents
+        # by not constantly reparsing the XSLT. This is definitely worthwhile for
+        # Mallard. We may find it's not worthwhile for DocBook when tested against
+        # real-world sites.
+
+        cmd = ['xsltproc',
+               '--xinclude',
+               '--stringparam', 'pintail.format', 'docbook']
+        cmd.extend(pintail.site.XslProvider.get_xsltproc_args('html', self, lang=lang))
+        cmd.extend([
+            '-o', self.get_target_path(lang),
+            os.path.join(self.site.tools_path, 'pintail-html-docbook-local.xsl'),
+            self.get_stage_path(lang)])
+        subprocess.call(cmd)
+
+
+    def get_media(self):
+        """
+        Get a list of referenced media files in the entire DocBook document.
+
+        This implementation looks for any local references in `fileref` attributes,
+        `xlink:href` attributes, and `url` attributes on `ulink` elements.
+        It returns references to all media files in the entire document,
+        even if they are referenced from a subpage.
+        This method also attempts to stage common content provided by Publican
+        if the document has been marked as a Publican document with the
+        `publican_doctype` config option.
+        """
+        refs = set()
+        def _accumulate_refs(node):
+            src = node.get('fileref', None)
+            if src is not None and ':' not in src:
+                refs.add(src)
+            href = node.get(XLINK_NS + 'href', None)
+            if href is not None and ':' not in href:
+                refs.add(href)
+            if node.tag == 'ulink':
+                href = node.get('url', None)
+                if href is not None and ':' not in href:
+                    refs.add(href)
+            for child in node:
+                _accumulate_refs(child)
+        _accumulate_refs(self._tree.getroot())
+
+        # If files don't exist, but Publican provides them, stage them.
+        if self.pbbrand is not None and self.pblang is not None:
+            for ref in refs:
+                if os.path.exists(os.path.join(self.source.get_source_path(), ref)):
+                    continue
+                stagepath = os.path.join(self.directory.get_stage_path(), ref)
+                if os.path.exists(stagepath):
+                    continue
+                if ref.startswith('Common_Content/'):
+                    rref = ref[15:]
+                else:
+                    continue
+                tryref = os.path.join('/usr/share/publican/Common_Content/', self.pbbrand, self.pblang, rref)
+                if os.path.exists(tryref):
+                    self.site.log('STAGE', self.directory.path + ref)
+                    pintail.site.Site._makedirs(os.path.dirname(stagepath))
+                    shutil.copyfile(tryref, stagepath)
+                    continue
+                tryref = os.path.join('/usr/share/publican/Common_Content/common/', self.pblang, rref)
+                if os.path.exists(tryref):
+                    self.site.log('STAGE', self.directory.path + ref)
+                    pintail.site.Site._makedirs(os.path.dirname(stagepath))
+                    shutil.copyfile(tryref, stagepath)
+
+        return refs
+
+
+    @classmethod
+    def create_pages(cls, source):
+        """
+        Create a list of `Page` objects for each output page of a DocBook document.
+
+        If the source uses the `docbook` config option, this method implementation
+        will create a `DocBookPage` object for the primary page. A DocBook document
+        may create multiple output pages. The primary page will create a list of
+        other pages in the document. This method returns a list containing the
+        primary page and any subpages it finds.
+        """
+        dbfile = source.site.config.get('docbook', source.name)
+        if dbfile is not None:
+            if os.path.exists(os.path.join(source.get_source_path(), dbfile)):
+                toppage = DocBookPage(source, dbfile)
+                return [toppage] + toppage.subpages
+        return []
+
+
+class DocBookSubPage(pintail.site.Page):
+    """
+    A subpage in a DocBook document.
+
+    A DocBook document can create multiple output files. There is exaclty one
+    `DocBookPage` object for each document. It can then have any number of
+    `DocBookSubPage` objects, referenced by the section id. The primary page
+    does most of the work, including building all HTML, but the subpages exist
+    for tracking and search purposes.
+    """
+
+    def __init__(self, db_page, element):
+        pintail.site.Page.__init__(self, db_page.source, db_page.source_file)
+        self._db_page = db_page
+        self._sect_id = element.get('id') or element.get(XML_NS + 'id')
+
+
+    @property
+    def page_id(self):
+        """
+        The simple id of the page.
+
+        This comes from the `id` attribute of the DocBook element that creates the page.
+        """
+        return self._sect_id
+
+
+    @property
+    def searchable(self):
+        """
+        Whether the page should be added to the search index.
+        """
+        return True
+
+
+    def get_title(self, hint=None, lang=None):
+        """
+        Get the title of the DocBook subpage.
+
+        This implementation prefers the `title` element in the `info` (or similar)
+        element, but will use the primary display title if an info title is not found.
+        """
+        el = self._db_page._get_tree(lang).getroot().xpath('//*[@id = "%s" or @xml:id = "%s"]' %
+                                                           (self._sect_id, self._sect_id))
+        return self._db_page.get_title_node(el[0], hint=hint)
+
+
+    def get_keywords(self, hint=None, lang=None):
+        """
+        Get the keywords of the DocBook subpage.
+
+        This implementation looks at the `keywordset` element. It makes a
+        comma-separated list from each `keyword` child element.
+        """
+        el = self._db_page._get_tree(lang).getroot().xpath('//*[@id = "%s" or @xml:id = "%s"]' %
+                                                           (self._sect_id, self._sect_id))
+        return self._db_page.get_keywords_node(el[0], hint=hint)
+
+
+    def get_content(self, hint=None, lang=None):
+        """
+        Get the full content of the DocBook subpage.
+
+        This implementation tries carefully not to include content from further
+        subpages in the content for this subpage.
+        """
+        el = self._db_page._get_tree(lang).getroot().xpath('//*[@id = "%s" or @xml:id = "%s"]' %
+                                                           (self._sect_id, self._sect_id))
+        return self._db_page.get_content_node(el[0], hint=hint)
+
+
+class DocBookTools(pintail.site.ToolsProvider, pintail.site.CssProvider):
+    """
+    A collection of tools for building DocBook pages.
+
+    This class contains class methods for various Pintail extenion points
+    that aren't `Page`.
+    """
 
     @classmethod
     def build_tools(cls, site):
+        """
+        Build tools to be used during the build.
+
+        This method implementation creates wrapper XSLT around the HTML transforms
+        from yelp-xsl, the custom XSLT provided for the site, and any additional
+        XSLT provided by extensions.
+        """
         db2html = os.path.join(site.yelp_xsl_path, 'xslt', 'docbook', 'html', 'db2html.xsl')
         mallink = os.path.join(site.yelp_xsl_path, 'xslt', 'mallard', 'common', 'mal-link.xsl')
 
@@ -201,8 +634,16 @@ class DocBookPage(pintail.site.Page, pintail.site.ToolsProvider, pintail.site.Cs
                  % (db2html, mallink, 'pintail-html.xsl'))
         fd.close()
 
+
     @classmethod
     def build_css(cls, site):
+        """
+        Build CSS for DocBook pages in the site.
+
+        This method implementation uses the yelp-xsl stylesheets to generate CSS,
+        so it always matches the built HTML files, and can reference params for
+        things like colors. It generates a separate CSS file for each language.
+        """
         xslpath = os.path.join(site.yelp_xsl_path, 'xslt')
 
         pintail.site.Site._makedirs(site.tools_path)
@@ -277,266 +718,4 @@ class DocBookPage(pintail.site.Page, pintail.site.ToolsProvider, pintail.site.Cs
                     fd.write(open(custom_css).read())
                     fd.close()
 
-    def _rewrite_publican_xml_file(self, source, target, entfile):
-        p = subprocess.Popen(['xmllint', '--dropdtd', source],
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        lines = p.communicate()[0].decode('utf-8').split('\n')
-        decl = None
-        if lines[0].startswith('<?xml'):
-            decl = lines.pop(0)
-        el = None
-        for line in lines:
-            if '<' in line:
-                el = line[line.index('<')+1:]
-                if el[0] != '!':
-                    if ' ' in el:
-                        el = el[:el.index(' ')]
-                    elif '>' in el:
-                        el = el[:el.index('>')]
-                    break
-        doctype = '<!DOCTYPE %s PUBLIC ' % el
-        if self.pbdoctype.startswith('4.'):
-            doctype += '"-//OASIS//DTD DocBook XML V%s//EN" ' % self.pbdoctype
-            doctype += '"http://www.oasis-open.org/docbook/xml/%s/docbookx.dtd" [\n' % self.pbdoctype
-        elif self.pbdoctype.startswith('5.'):
-            FIXME
-        else:
-            FIXME
-        if entfile is not None:
-            doctype += '<!ENTITY %% BOOK_ENTITIES SYSTEM "%s">\n' % entfile
-            doctype += '%BOOK_ENTITIES;\n'
-        doctype += ']>\n'
-        fd = open(target, 'w')
-        if decl is not None:
-            fd.write(decl + '\n')
-        fd.write(doctype)
-        for line in lines:
-            fd.write(line + '\n')
-        fd.close()
 
-    def _stage_page_publican(self):
-        # Publican does some weird things to DocBook, including rewriting the DOCTYPE
-        # in a way that lets you write non-well-formed XML that can't be read by any
-        # other tool. Pintail can pretend to be Publican.
-        pbdir = os.path.join(self.directory.get_stage_path(), '__publican__')
-        pintail.site.Site._makedirs(pbdir)
-
-        # Look for the publican.cfg file and extract some values from it.
-        cfgdir = self.directory.get_source_path()
-        cfg = os.path.join(cfgdir, 'publican.cfg')
-        while not os.path.exists(cfg):
-            if os.path.dirname(cfgdir) == cfgdir:
-                break
-            cfgdir = os.path.dirname(cfgdir)
-            cfg = os.path.join(cfgdir, 'publican.cfg')
-        if os.path.exists(cfg):
-            for line in open(cfg):
-                if line.startswith('brand:'):
-                    self.pbbrand = line[line.index(':')+1:].strip()
-                if line.startswith('xml_lang:'):
-                    self.pblang = line[line.index(':')+1:].strip()
-
-        # Rewrite the DOCTYPE of all .xml files, using a .ent file with the
-        # same basename if available. This is the craziness Publican does.
-        xmlfiles = []
-        entfile = None
-        dpath = self.directory.get_source_path()
-        for xml in os.listdir(dpath):
-            if not os.path.isfile(os.path.join(dpath, xml)):
-                continue
-            if xml.endswith('.xml'):
-                xmlfiles.append(xml)
-            elif xml == os.path.splitext(self.source_file)[0] + '.ent':
-                entfile = xml
-                shutil.copyfile(os.path.join(dpath, entfile), os.path.join(pbdir, entfile))
-        for xml in xmlfiles:
-            self._rewrite_publican_xml_file(os.path.join(dpath, xml),
-                                            os.path.join(pbdir, xml),
-                                            entfile)
-
-        # Publican also ships "common content", some of which is required
-        # for parsing. But even the common content has to be rewritten to
-        # reference the .ent file in your repo. We can only do this if we
-        # found a brand and language in publican.cfg.
-        if self.pbbrand is not None and self.pblang is not None:
-            ccdir = os.path.join(pbdir, 'Common_Content')
-            pintail.site.Site._makedirs(ccdir)
-            branddir = os.path.join('/usr/share/publican/Common_Content/', self.pbbrand, self.pblang)
-            commondir = os.path.join('/usr/share/publican/Common_Content/common/', self.pblang)
-            brandfiles = [os.path.join(branddir, xml) for xml in os.listdir(branddir)]
-            commonfiles = [os.path.join(commondir, xml) for xml in os.listdir(commondir)]
-            donefiles = set()
-            for filename in brandfiles + commonfiles:
-                bname = os.path.basename(filename)
-                if bname in donefiles:
-                    continue
-                if not os.path.isfile(filename):
-                    continue
-                if filename.endswith('.xml'):
-                    donefiles.add(bname)
-                    self._rewrite_publican_xml_file(filename,
-                                                    os.path.join(ccdir, bname),
-                                                    '../' + entfile)
-
-        # Finally, make a baked XML file in the location the rest of Pintail expects.
-        subprocess.call(['xmllint', '--xinclude', '--noent', '--loaddtd',
-                         '-o', self.get_stage_path(),
-                         os.path.join(pbdir, self.source_file)])
-
-    def stage_page(self):
-        pintail.site.Site._makedirs(self.directory.get_stage_path())
-        self.pbdoctype = self.site.config.get('publican_doctype', self.directory.path)
-        if self.pbdoctype is not None:
-            self._stage_page_publican()
-        else:
-            subprocess.call(['xmllint', '--xinclude', '--noent',
-                             '-o', self.get_stage_path(),
-                             self.get_source_path()])
-
-    def get_cache_data(self, lang=None):
-        ret = None
-        try:
-            ret = etree.Element(PINTAIL_NS + 'external')
-            ret.set('id', self.directory.path + 'index')
-            ret.set(SITE_NS + 'dir', self.directory.path)
-            dbfile = self._get_tree(lang)
-            dbfile.xinclude()
-            info = None
-            title = None
-            for child in dbfile.getroot():
-                if not isinstance(child.tag, str):
-                    continue
-                if child.tag == (DOCBOOK_NS + 'info'):
-                    info = child
-                elif etree.QName(child.tag).namespace is None and child.tag.endswith('info'):
-                    info = child
-                elif child.tag in ('title', DOCBOOK_NS + 'title'):
-                    title = child
-                    break
-            if title is None and info is not None:
-                for child in info:
-                    if child.tag in ('title', DOCBOOK_NS + 'title'):
-                        title = child
-                        break
-            if title is not None:
-                title = title.xpath('string(.)')
-                titlen = etree.Element(MAL_NS + 'title')
-                titlen.text = title
-                ret.append(titlen)
-        except:
-            pass
-        return ret
-
-    def build_html(self, lang=None):
-        if lang is None:
-            self.site.log('HTML', self.site_id)
-        else:
-            self.site.log('HTML', lang + ' ' + self.site_id)
-
-        if DocBookPage._html_transform is None:
-            DocBookPage._html_transform = etree.XSLT(etree.parse(os.path.join(self.site.tools_path,
-                                                                              'pintail-html-docbook-local.xsl')))
-        args = {}
-        args['pintail.format'] = etree.XSLT.strparam('docbook')
-        for pair in pintail.site.XslProvider.get_all_xsl_params('html', self, lang=lang):
-            args[pair[0]] = etree.XSLT.strparam(pair[1])
-        tree = self._get_tree(lang)
-        DocBookPage._html_transform(tree, **args)
-
-        return
-        # Leaving in this code to call xsltproc for now. It turns out that using
-        # etree.XSLT is slower on each individual run than calling xsltproc, oddly
-        # enough. But it gets you performance gains over large numbers of documents
-        # by not constantly reparsing the XSLT. This is definitely worthwhile for
-        # Mallard. We may find it's not worthwhile for DocBook when tested against
-        # real-world sites.
-
-        cmd = ['xsltproc',
-               '--xinclude',
-               '--stringparam', 'pintail.format', 'docbook']
-        cmd.extend(pintail.site.XslProvider.get_xsltproc_args('html', self, lang=lang))
-        cmd.extend([
-            '-o', self.get_target_path(lang),
-            os.path.join(self.site.tools_path, 'pintail-html-docbook-local.xsl'),
-            self.get_stage_path(lang)])
-        subprocess.call(cmd)
-
-    def get_media(self):
-        refs = set()
-        def _accumulate_refs(node):
-            src = node.get('fileref', None)
-            if src is not None and ':' not in src:
-                refs.add(src)
-            href = node.get(XLINK_NS + 'href', None)
-            if href is not None and ':' not in href:
-                refs.add(href)
-            if node.tag == 'ulink':
-                href = node.get('url', None)
-                if href is not None and ':' not in href:
-                    refs.add(href)
-            for child in node:
-                _accumulate_refs(child)
-        _accumulate_refs(self._tree.getroot())
-
-        # If files don't exist, but Publican provides them, stage them.
-        if self.pbbrand is not None and self.pblang is not None:
-            for ref in refs:
-                if os.path.exists(os.path.join(self.directory.get_source_path(), ref)):
-                    continue
-                stagepath = os.path.join(self.directory.get_stage_path(), ref)
-                if os.path.exists(stagepath):
-                    continue
-                if ref.startswith('Common_Content/'):
-                    rref = ref[15:]
-                else:
-                    continue
-                tryref = os.path.join('/usr/share/publican/Common_Content/', self.pbbrand, self.pblang, rref)
-                if os.path.exists(tryref):
-                    self.site.log('STAGE', self.directory.path + ref)
-                    pintail.site.Site._makedirs(os.path.dirname(stagepath))
-                    shutil.copyfile(tryref, stagepath)
-                    continue
-                tryref = os.path.join('/usr/share/publican/Common_Content/common/', self.pblang, rref)
-                if os.path.exists(tryref):
-                    self.site.log('STAGE', self.directory.path + ref)
-                    pintail.site.Site._makedirs(os.path.dirname(stagepath))
-                    shutil.copyfile(tryref, stagepath)
-
-        return refs
-
-    @classmethod
-    def get_pages(cls, directory, filename):
-        dbfile = directory.site.config.get('docbook', directory.path)
-        if filename == dbfile:
-            toppage = DocBookPage(directory, filename)
-            return [toppage] + toppage.subpages
-        return []
-
-class DocBookSubPage(pintail.site.Page):
-    def __init__(self, db_page, element):
-        pintail.site.Page.__init__(self, db_page.directory, db_page.source_file)
-        self._db_page = db_page
-        self._sect_id = element.get('id') or element.get(XML_NS + 'id')
-
-    @property
-    def page_id(self):
-        return self._sect_id
-
-    @property
-    def searchable(self):
-        return True
-
-    def get_title(self, hint=None, lang=None):
-        el = self._db_page._get_tree(lang).getroot().xpath('//*[@id = "%s" or @xml:id = "%s"]' %
-                                                           (self._sect_id, self._sect_id))
-        return self._db_page.get_title_node(el[0], hint=hint)
-
-    def get_keywords(self, hint=None, lang=None):
-        el = self._db_page._get_tree(lang).getroot().xpath('//*[@id = "%s" or @xml:id = "%s"]' %
-                                                           (self._sect_id, self._sect_id))
-        return self._db_page.get_keywords_node(el[0], hint=hint)
-
-    def get_content(self, hint=None, lang=None):
-        el = self._db_page._get_tree(lang).getroot().xpath('//*[@id = "%s" or @xml:id = "%s"]' %
-                                                           (self._sect_id, self._sect_id))
-        return self._db_page.get_content_node(el[0], hint=hint)

--- a/pintail/ducktype.py
+++ b/pintail/ducktype.py
@@ -1,5 +1,5 @@
 # pintail - Build static sites from collections of Mallard documents
-# Copyright (c) 2015-2016 Shaun McCance <shaunm@gnome.org>
+# Copyright (c) 2015-2020 Shaun McCance <shaunm@gnome.org>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,32 +14,53 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import subprocess
 
 import pintail.site
 import pintail.mallard
 
 class DucktypePage(pintail.mallard.MallardPage):
-    def __init__(self, directory, source_file):
-        pintail.mallard.MallardPage.__init__(self, directory, source_file)
+    """
+    A page written in Ducktype, a compact syntax for Mallard.
+
+    The DucktypePage class works by converting Ducktype to Mallard XML in the stage,
+    then letting the MallardPage class do the rest of the work.
+    """
+    def __init__(self, source, filename):
+        super().__init__(source, filename)
 
     @property
     def stage_file(self):
+        """
+        The name of the staged XML file for this Ducktype page.
+        """
         if self.source_file.endswith('.duck'):
             return self.source_file[:-5] + '.page'
         else:
             return self.source_file
 
     def stage_page(self):
+        """
+        Create a Mallard XML file in the stage.
+        """
         pintail.site.Site._makedirs(self.directory.get_stage_path())
         subprocess.call(['ducktype',
                          '-o', self.get_stage_path(),
                          self.get_source_path()])
 
     @classmethod
-    def get_pages(cls, directory, filename):
-        if filename.endswith('.duck'):
-            return [DucktypePage(directory, filename)]
-        return []
-
+    def create_pages(cls, source):
+        """
+        Create a list of pages for all Ducktype files in a source directory.
+        """
+        pages = []
+        exclude = (source.site.config.get('exclude_files', source.name) or '').split()
+        for filename in os.listdir(source.get_source_path()):
+            if filename in exclude:
+                continue
+            if os.path.isfile(os.path.join(source.get_source_path(), filename)):
+                if filename.endswith('.duck'):
+                    pages.append(DucktypePage(source, filename))
+        return pages
 

--- a/pintail/git.py
+++ b/pintail/git.py
@@ -1,5 +1,5 @@
 # pintail - Build static sites from collections of Mallard documents
-# Copyright (c) 2015 Shaun McCance <shaunm@gnome.org>
+# Copyright (c) 2015-2020 Shaun McCance <shaunm@gnome.org>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,44 +19,74 @@ import subprocess
 
 import pintail.site
 
-class GitDirectory(pintail.site.Directory, pintail.site.XslProvider):
-    def __init__(self, site, path, *, parent=None):
-        self.repo = site.config.get('git_repository', path)
-        self.branch = site.config.get('git_branch', path) or 'master'
+
+class GitSource(pintail.site.Source, pintail.site.XslProvider):
+    """
+    A source directory from a remote git repository.
+
+    If a directory or other source in the config file uses the `git_repository` option,
+    this source will be used to fetch pages from another git repository.
+    This source recognizes the following config options:
+
+    * `git_repository` - The git repository URL, suitable to pass to `git clone`.
+    * `git_branch` - The remote git branch to check out.
+    * `git_directory` - The directory in the git repository where pages can be found.
+    * `git_update` - Whether to update the git clone on each run, `true` or `false`.
+    """
+
+    def __init__(self, directory, name):
+        self.repo = directory.site.config.get('git_repository', name)
+        self.branch = directory.site.config.get('git_branch', name) or 'master'
         self.repodir = (self.repo.replace('/', '!') + '@@' +
                         self.branch.replace('/', '!'))
-        self.absrepodir = os.path.join(site.pindir, 'git', self.repodir)
+        self.absrepodir = os.path.join(directory.site.pindir, 'git', self.repodir)
+
+        super().__init__(directory, name)
 
         if os.path.exists(self.absrepodir):
-            if site.config._update and site.config.get('git_update', path) != 'false':
-                site.log('UPDATE', self.repo + '@' + self.branch)
+            if self.site.config._update and self.site.config.get('git_update', name) != 'false':
+                self.site.log('UPDATE', self.repo + '@' + self.branch)
                 p = subprocess.Popen(['git', 'pull', '-q', '-r',
                                       'origin', self.branch],
                                      cwd=self.absrepodir)
                 p.communicate()
         else:
-            site.log('CLONE', self.repo + '@' + self.branch)
-            pintail.site.Site._makedirs(os.path.join(site.pindir, 'git'))
-            p = subprocess.Popen(['git', 'clone', '-q',
+            self.site.log('CLONE', self.repo + '@' + self.branch)
+            pintail.site.Site._makedirs(os.path.join(self.site.pindir, 'git'))
+            p = subprocess.Popen(['git', 'clone', '-q', '--depth', '1',
                                   '-b', self.branch, '--single-branch',
                                   self.repo, self.repodir],
-                                 cwd=os.path.join(site.pindir, 'git'))
+                                 cwd=os.path.join(self.site.pindir, 'git'))
             p.communicate()
 
-        super().__init__(site, path, parent=parent)
 
     def get_source_path(self):
+        """
+        The absolute path to the source directory for this source.
+        """
         return os.path.join(self.absrepodir,
-                            self.site.config.get('git_directory', self.path) or '')
+                            self.site.config.get('git_directory', self.name) or '')
+
 
     @classmethod
-    def is_special_path(cls, site, path):
-        repo = site.config.get('git_repository', path)
+    def create_sources(cls, directory, name):
+        """
+        Return a list of source objects for a remote git source.
+
+        If a directory or other source in the config file uses `git_repository`,
+        this function will return a list with a single git source.
+        """
+        repo = directory.site.config.get('git_repository', name)
         if repo is not None:
-            return True
+            return [cls(directory, name)]
+        return []
+
 
     @classmethod
     def get_xsl_params(cls, output, obj, lang=None):
+        """
+        Get a list of XSLT params about the git location.
+        """
         if not (output == 'html' and isinstance(obj, pintail.site.Page)):
             return []
         if isinstance(obj.directory, cls):

--- a/pintail/mallard.py
+++ b/pintail/mallard.py
@@ -1,5 +1,5 @@
 # pintail - Build static sites from collections of Mallard documents
-# Copyright (c) 2015-2016 Shaun McCance <shaunm@gnome.org>
+# Copyright (c) 2015-2020 Shaun McCance <shaunm@gnome.org>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -31,21 +31,23 @@ NS_MAP = {
     'cache': 'http://projectmallard.org/cache/1.0/'
 }
 
-class MallardPage(pintail.site.Page,
-                  pintail.site.ToolsProvider,
-                  pintail.site.CssProvider,
-                  pintail.site.XslProvider):
+class MallardPage(pintail.site.Page):
+    """
+    An individual Mallard page in a directory.
+    """
 
     _html_transform = None
 
-    def __init__(self, directory, source_file):
-        pintail.site.Page.__init__(self, directory, source_file)
+    def __init__(self, source, filename):
+        super().__init__(source, filename)
+
         self.stage_page()
         self._tree = etree.parse(self.get_stage_path())
         etree.XInclude()(self._tree.getroot())
         self._mallard_page_id = self._tree.getroot().get('id')
         self._langtrees = {}
         self._notlangs = set()
+
 
     def _get_tree(self, lang=None):
         if lang is None or lang in self._notlangs:
@@ -57,16 +59,247 @@ class MallardPage(pintail.site.Page,
         self._notlangs.add(lang)
         return self._tree
 
+
     @property
     def page_id(self):
+        """
+        The simple id of the page.
+
+        This is always the `id` attribute of the `page` element,
+        regardless of the filename.
+        """
         return self._mallard_page_id
+
 
     @property
     def searchable(self):
+        """
+        Whether the page should be added to the search index.
+        """
         return True
+
+
+    def stage_page(self):
+        """
+        Create a Mallard file in the stage.
+        """
+        pintail.site.Site._makedirs(self.directory.get_stage_path())
+        subprocess.call(['xmllint', '--xinclude',
+                         '-o', self.get_stage_path(),
+                         self.get_source_path()])
+
+
+    def get_cache_data(self, lang=None):
+        """
+        Get XML data to add to the cache, as an lxml.etree.Element object.
+        """
+        def _get_node_cache(node):
+            ret = etree.Element(node.tag)
+            ret.text = '\n'
+            ret.tail = '\n'
+            for attr in node.keys():
+                if attr != 'id':
+                    ret.set(attr, node.get(attr))
+            if node.tag == MAL_NS + 'page':
+                ret.set('id', self.site_id)
+            elif node.get('id', None) is not None:
+                ret.set('id', self.site_id + '#' + node.get('id'))
+            ret.set(SITE_NS + 'dir', self.directory.path)
+            for child in node:
+                if child.tag == MAL_NS + 'info':
+                    info = etree.Element(child.tag)
+                    ret.append(info)
+                    for infochild in child:
+                        if infochild.tag == MAL_NS + 'link':
+                            xref = infochild.get('xref', None)
+                            if xref is None or xref.startswith('/'):
+                                info.append(copy.deepcopy(infochild))
+                            else:
+                                link = etree.Element(infochild.tag)
+                                link.set('xref', self.directory.path + xref)
+                                for attr in infochild.keys():
+                                    if attr != 'xref':
+                                        link.set(attr, infochild.get(attr))
+                                for linkchild in infochild:
+                                    link.append(linkchild)
+                                info.append(copy.deepcopy(link))
+                        else:
+                            info.append(copy.deepcopy(infochild))
+                if child.tag == MAL_NS + 'title':
+                    ret.append(copy.deepcopy(child))
+                elif child.tag == MAL_NS + 'section':
+                    ret.append(_get_node_cache(child))
+            return ret
+        page = _get_node_cache(self._get_tree(lang).getroot())
+        page.set(CACHE_NS + 'href', self.get_stage_path(lang))
+        return page
+
+
+    def build_html(self, lang=None):
+        """
+        Build the HTML file for this page, possibly translated.
+        """
+        if lang is None:
+            self.site.log('HTML', self.site_id)
+        else:
+            self.site.log('HTML', lang + ' ' + self.site_id)
+        if MallardPage._html_transform is None:
+            MallardPage._html_transform = etree.XSLT(etree.parse(os.path.join(self.site.tools_path,
+                                                                              'pintail-html-mallard-local.xsl')))
+        args = {}
+        args['pintail.format'] = etree.XSLT.strparam('mallard')
+        for pair in pintail.site.XslProvider.get_all_xsl_params('html', self, lang=lang):
+            args[pair[0]] = etree.XSLT.strparam(pair[1])
+        MallardPage._html_transform(self._get_tree(lang), **args)
+
+
+    def get_media(self):
+        """
+        Get a list of referenced media files.
+
+        This implementation looks for any local references in any
+        `src` or `href` attributes.
+        """
+        refs = set()
+        def _accumulate_refs(node):
+            src = node.get('src', None)
+            if src is not None and ':' not in src and src != '#':
+                refs.add(src)
+            href = node.get('href', None)
+            if href is not None and ':' not in href:
+                refs.add(href)
+            for child in node:
+                _accumulate_refs(child)
+        _accumulate_refs(self._tree.getroot())
+        return refs
+
+
+    def get_title(self, hint=None, lang=None):
+        """
+        Get the title of the Mallard page.
+
+        This implementation prefers Mallard text titles. Additionally, it will
+        prefer the text title with `role="search"` if `hint` is `"search"`.
+        """
+        tree = self._get_tree(lang)
+        res = []
+        if hint == 'search':
+            res = tree.xpath('/mal:page/mal:info/mal:title[@type="search"]',
+                             namespaces=NS_MAP)
+            if len(res) == 0:
+                res = tree.xpath('/mal:page/mal:info/mal:title[@type="text"][@role="search"]',
+                                 namespaces=NS_MAP)
+        if len(res) == 0:
+            res = tree.xpath('/mal:page/mal:info/mal:title[@type="text"][not(@role)]',
+                             namespaces=NS_MAP)
+        if len(res) == 0:
+            res = tree.xpath('/mal:page/mal:title', namespaces=NS_MAP)
+        if len(res) == 0:
+            return ''
+        else:
+            return res[-1].xpath('string(.)')
+
+
+    def get_desc(self, hint=None, lang=None):
+        """
+        Get the desc of the Mallard page.
+
+        This implementation prefers Mallard text descs. Additionally, it will
+        prefer the text desc with `role="search"` if `hint` is `"search"`.
+        """
+        tree = self._get_tree(lang)
+        res = []
+        if hint == 'search':
+            res = tree.xpath('/mal:page/mal:info/mal:desc[@type="search"]',
+                             namespaces=NS_MAP)
+            if len(res) == 0:
+                res = tree.xpath('/mal:page/mal:info/mal:desc[@type="text"][@role="search"]',
+                                 namespaces=NS_MAP)
+        if len(res) == 0:
+            res = tree.xpath('/mal:page/mal:info/mal:desc[@type="text"][not(@role)]',
+                             namespaces=NS_MAP)
+        if len(res) == 0:
+            res = tree.xpath('/mal:page/mal:info/mal:desc[not(@type)]', namespaces=NS_MAP)
+        if len(res) == 0:
+            return ''
+        else:
+            return res[-1].xpath('string(.)')
+
+
+    def get_keywords(self, hint=None, lang=None):
+        """
+        Get the keywords of the Mallard page.
+
+        This implementation uses the Mallard `keywords` element,
+        which is expected to be finalized in Mallard 1.2.
+        """
+        tree = self._get_tree(lang)
+        res = tree.xpath('/mal:page/mal:info/mal:keywords', namespaces=NS_MAP)
+        if len(res) == 0:
+            return ''
+        else:
+            return res[-1].xpath('string(.)')
+
+
+    def get_content(self, hint=None, lang=None):
+        """
+        Get the full content of the Mallard page.
+        """
+        # FIXME: could be good to have smarter block/inline handling, conditional
+        # processing, correct block fallback. Probably should just have a mal2text
+        # in yelp-xsl.
+        tree = self._get_tree(lang)
+        def _accumulate_text(node):
+            ret = ''
+            for child in node:
+                if not isinstance(child.tag, str):
+                    continue
+                if node.tag == MAL_NS + 'info':
+                    continue
+                ret += child.text or ''
+                ret += _accumulate_text(child)
+                ret += child.tail or ''
+            return ret
+        return _accumulate_text(tree.getroot())
+
+
+    @classmethod
+    def create_pages(cls, source):
+        """
+        Create a list of `Page` objects for each Mallard page in a source.
+
+        This method implementation looks for all files with the `.page` extension.
+        """
+        pages = []
+        exclude = (source.site.config.get('exclude_files', source.name) or '').split()
+        for filename in os.listdir(source.get_source_path()):
+            if filename in exclude:
+                continue
+            if os.path.isfile(os.path.join(source.get_source_path(), filename)):
+                if filename.endswith('.page'):
+                    pages.append(MallardPage(source, filename))
+        return pages
+
+
+class MallardTools(pintail.site.ToolsProvider,
+                   pintail.site.CssProvider,
+                   pintail.site.XslProvider):
+    """
+    A collection of tools for building Mallard pages.
+
+    This class contains class methods for various Pintail extenion points
+    that aren't `Page`.
+    """
 
     @classmethod
     def build_tools(cls, site):
+        """
+        Build tools to be used during the build.
+
+        This method implementation creates wrapper XSLT around the HTML transforms
+        from yelp-xsl, the custom XSLT provided for the site, and any additional
+        XSLT provided by extensions.
+        """
         mal2html = os.path.join(site.yelp_xsl_path, 'xslt', 'mallard', 'html', 'mal2html.xsl')
 
         fd = open(os.path.join(site.tools_path, 'pintail-html-mallard-local.xsl'), 'w')
@@ -90,8 +323,16 @@ class MallardPage(pintail.site.Page,
                  % (mal2html, 'pintail-html.xsl'))
         fd.close()
 
+
     @classmethod
     def build_css(cls, site):
+        """
+        Build CSS for Mallard pages in the site.
+
+        This method implementation uses the yelp-xsl stylesheets to generate CSS,
+        so it always matches the built HTML files, and can reference params for
+        things like colors. It generates a separate CSS file for each language.
+        """
         xslpath = os.path.join(site.yelp_xsl_path, 'xslt')
 
         pintail.site.Site._makedirs(site.tools_path)
@@ -164,149 +405,12 @@ class MallardPage(pintail.site.Page,
                     fd.write(open(custom_css).read())
                     fd.close()
 
-    def stage_page(self):
-        pintail.site.Site._makedirs(self.directory.get_stage_path())
-        subprocess.call(['xmllint', '--xinclude',
-                         '-o', self.get_stage_path(),
-                         self.get_source_path()])
-
-    def get_cache_data(self, lang=None):
-        def _get_node_cache(node):
-            ret = etree.Element(node.tag)
-            ret.text = '\n'
-            ret.tail = '\n'
-            for attr in node.keys():
-                if attr != 'id':
-                    ret.set(attr, node.get(attr))
-            if node.tag == MAL_NS + 'page':
-                ret.set('id', self.site_id)
-            elif node.get('id', None) is not None:
-                ret.set('id', self.site_id + '#' + node.get('id'))
-            ret.set(SITE_NS + 'dir', self.directory.path)
-            for child in node:
-                if child.tag == MAL_NS + 'info':
-                    info = etree.Element(child.tag)
-                    ret.append(info)
-                    for infochild in child:
-                        if infochild.tag == MAL_NS + 'link':
-                            xref = infochild.get('xref', None)
-                            if xref is None or xref.startswith('/'):
-                                info.append(copy.deepcopy(infochild))
-                            else:
-                                link = etree.Element(infochild.tag)
-                                link.set('xref', self.directory.path + xref)
-                                for attr in infochild.keys():
-                                    if attr != 'xref':
-                                        link.set(attr, infochild.get(attr))
-                                for linkchild in infochild:
-                                    link.append(linkchild)
-                                info.append(copy.deepcopy(link))
-                        else:
-                            info.append(copy.deepcopy(infochild))
-                if child.tag == MAL_NS + 'title':
-                    ret.append(copy.deepcopy(child))
-                elif child.tag == MAL_NS + 'section':
-                    ret.append(_get_node_cache(child))
-            return ret
-        page = _get_node_cache(self._get_tree(lang).getroot())
-        page.set(CACHE_NS + 'href', self.get_stage_path(lang))
-        return page
-
-    def build_html(self, lang=None):
-        if lang is None:
-            self.site.log('HTML', self.site_id)
-        else:
-            self.site.log('HTML', lang + ' ' + self.site_id)
-        if MallardPage._html_transform is None:
-            MallardPage._html_transform = etree.XSLT(etree.parse(os.path.join(self.site.tools_path,
-                                                                              'pintail-html-mallard-local.xsl')))
-        args = {}
-        args['pintail.format'] = etree.XSLT.strparam('mallard')
-        for pair in pintail.site.XslProvider.get_all_xsl_params('html', self, lang=lang):
-            args[pair[0]] = etree.XSLT.strparam(pair[1])
-        MallardPage._html_transform(self._get_tree(lang), **args)
-
-
-    def get_media(self):
-        refs = set()
-        def _accumulate_refs(node):
-            src = node.get('src', None)
-            if src is not None and ':' not in src and src != '#':
-                refs.add(src)
-            href = node.get('href', None)
-            if href is not None and ':' not in href:
-                refs.add(href)
-            for child in node:
-                _accumulate_refs(child)
-        _accumulate_refs(self._tree.getroot())
-        return refs
-
-    def get_title(self, hint=None, lang=None):
-        tree = self._get_tree(lang)
-        res = []
-        if hint == 'search':
-            res = tree.xpath('/mal:page/mal:info/mal:title[@type="search"]',
-                             namespaces=NS_MAP)
-            if len(res) == 0:
-                res = tree.xpath('/mal:page/mal:info/mal:title[@type="text"][@role="search"]',
-                                 namespaces=NS_MAP)
-        if len(res) == 0:
-            res = tree.xpath('/mal:page/mal:info/mal:title[@type="text"][not(@role)]',
-                             namespaces=NS_MAP)
-        if len(res) == 0:
-            res = tree.xpath('/mal:page/mal:title', namespaces=NS_MAP)
-        if len(res) == 0:
-            return ''
-        else:
-            return res[-1].xpath('string(.)')
-
-    def get_desc(self, hint=None, lang=None):
-        tree = self._get_tree(lang)
-        res = []
-        if hint == 'search':
-            res = tree.xpath('/mal:page/mal:info/mal:desc[@type="search"]',
-                             namespaces=NS_MAP)
-            if len(res) == 0:
-                res = tree.xpath('/mal:page/mal:info/mal:desc[@type="text"][@role="search"]',
-                                 namespaces=NS_MAP)
-        if len(res) == 0:
-            res = tree.xpath('/mal:page/mal:info/mal:desc[@type="text"][not(@role)]',
-                             namespaces=NS_MAP)
-        if len(res) == 0:
-            res = tree.xpath('/mal:page/mal:info/mal:desc[not(@type)]', namespaces=NS_MAP)
-        if len(res) == 0:
-            return ''
-        else:
-            return res[-1].xpath('string(.)')
-
-    def get_keywords(self, hint=None, lang=None):
-        tree = self._get_tree(lang)
-        res = tree.xpath('/mal:page/mal:info/mal:keywords', namespaces=NS_MAP)
-        if len(res) == 0:
-            return ''
-        else:
-            return res[-1].xpath('string(.)')
-
-    def get_content(self, hint=None, lang=None):
-        # FIXME: could be good to have smarter block/inline handling, conditional
-        # processing, correct block fallback. Probably should just have a mal2text
-        # in yelp-xsl.
-        tree = self._get_tree(lang)
-        def _accumulate_text(node):
-            ret = ''
-            for child in node:
-                if not isinstance(child.tag, str):
-                    continue
-                if node.tag == MAL_NS + 'info':
-                    continue
-                ret += child.text or ''
-                ret += _accumulate_text(child)
-                ret += child.tail or ''
-            return ret
-        return _accumulate_text(tree.getroot())
 
     @classmethod
     def get_xsl_params(cls, output, obj, lang=None):
+        """
+        Get a list of XSLT params for Mallard transforms.
+        """
         if not (output == 'html' and isinstance(obj, MallardPage)):
             return []
         d = obj.directory
@@ -317,11 +421,5 @@ class MallardPage(pintail.site.Page,
             if ed == 'True':
                 return [('mal2html.editor_mode', '1')]
             d = d.parent
-        return []
-
-    @classmethod
-    def get_pages(cls, directory, filename):
-        if filename.endswith('.page'):
-            return [MallardPage(directory, filename)]
         return []
 

--- a/pintail/search.py
+++ b/pintail/search.py
@@ -1,5 +1,5 @@
 # pintail - Build static sites from collections of Mallard documents
-# Copyright (c) 2016 Shaun McCance <shaunm@gnome.org>
+# Copyright (c) 2016-2020 Shaun McCance <shaunm@gnome.org>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,14 +17,32 @@
 import pintail.site
 
 class SearchProvider(pintail.site.Extendable):
+    """
+    An extension point to provide search for the site.
+    """
     def __init__(self, site):
         self.site = site
 
     def index_site(self):
+        """
+        Build the search index for the site.
+
+        This method calls `index_directory` on each directory in the site.
+        Search providers probably do not need to override this method.
+        """
         for subdir in self.site.root.iter_directories():
             self.index_directory(subdir)
 
     def index_directory(self, directory):
+        """
+        Build the search index for the directory.
+
+        This method looks at each page in the directory.
+        If the page is searchable, it calls `index_page` on the page,
+        then calls `index_page` again once for each language returned by
+        the translation provider for the directory.
+        Search providers probably do not need to override this method.
+        """
         langs = [None]
         if not self.site.get_filter(directory):
             return
@@ -42,4 +60,10 @@ class SearchProvider(pintail.site.Extendable):
                 self.index_page(page, lang=lc)
 
     def index_page(self, page, lang=None):
+        """
+        Build the search index for the directory.
+
+        Search providers should override this method to add data for the
+        page to the search index.
+        """
         pass

--- a/pintail/site.py
+++ b/pintail/site.py
@@ -581,6 +581,7 @@ class Directory(Extendable):
                                                      'Duplicate page id ' + page.page_id)
                     by_page_id[page.page_id] = page
                     self.pages.append(page)
+                    source.pages.append(page)
 
 
     def iter_directories(self):
@@ -865,6 +866,7 @@ class Source(Extendable):
     def __init__(self, directory, name):
         self.directory = directory
         self.name = name
+        self.pages = []
         self.site = self.directory.site
 
 

--- a/pintail/site.py
+++ b/pintail/site.py
@@ -1,5 +1,5 @@
 # pintail - Build static sites from collections of Mallard documents
-# Copyright (c) 2015-2016 Shaun McCance <shaunm@gnome.org>
+# Copyright (c) 2015-2020 Shaun McCance <shaunm@gnome.org>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -45,8 +45,19 @@ class DuplicatePageException(Exception):
 
 
 class Extendable:
+    """
+    The base class for all plugins in Pintail.
+    """
     @classmethod
     def iter_subclasses(cls, filter=None):
+        """
+        Iterate over all subclasses, recursing to any depth.
+
+        This is a convenient way to iterate all plugins of a certain type.
+        The optional `filter` parameter lets you provide a name of a function.
+        A class will only be yielded if it defines that function explicitly,
+        rather than inherits it from a parent class.
+        """
         for cls in cls.__subclasses__():
             if filter is None or filter in cls.__dict__:
                 yield cls
@@ -54,28 +65,100 @@ class Extendable:
 
 
 class ToolsProvider(Extendable):
+    """
+    Extension point to provide extra tools to be used during the build.
+
+    This method allows extensions to create any tools or other files they need
+    during the build process. This is most frequently used to create XSLT files
+    that are either used directly in `build_html`, or are inserted as customizations
+    using `XslProvider.get_xsl`.
+    """
     @classmethod
     def build_tools(cls, site):
+        """
+        Build tools to be used during the build.
+
+        Extensions should override this method to create any tools they need
+        later in the build process.
+        """
         pass
 
 
 class CssProvider(Extendable):
+    """
+    Extension point to provide CSS files in the built site.
+    """
     @classmethod
     def build_css(cls, site):
+        """
+        Build CSS for the site.
+
+        Extensions should override tis method to create any CSS files that
+        are referenced from built HTML files.
+        """
         pass
 
 
 class XslProvider(Extendable):
+    """
+    Extension point to provide XSLT or XSLT params.
+
+    This extension point allows you to provide extra XSLT files with `get_xsl`,
+    as well as provide XSLT params with `get_xsl_params`. You can implement
+    only one or both as needed.
+    """
+
     @classmethod
     def get_xsl(cls, site):
+        """
+        Get a list of additional XSLT files to include.
+
+        Extensions should implement this method if they have additional XSLT files
+        that should get included into the main transformations. It is called by
+        `Site.get_custom_xsl` when generating XSLT to build files. If you need to
+        generate the XSLT files as well, implement `ToolsProvider`.
+        """
         return []
+
 
     @classmethod
     def get_xsl_params(cls, output, obj, lang=None):
+        """
+        Get a list of XSLT params provided by an extension.
+
+        Implementations of this method are called by `get_all_xsl_params`.
+        Extensions should use this to provide additional XSLT params.
+        The return value is a list of tuples, where each tuple is a pair with
+        the param name and the param value. The param value is always a string.
+
+        The `output` parameter is a string specifying the output format. It is
+        usually `"html"`, but extensions could create other output formats.
+
+        The `obj` parameter is an object that a transform will be applied to.
+        It is usually an instance of a `Page` subclass, but it could be something
+        else. Always check `obj` before making assumptions.
+        """
         return []
+
 
     @classmethod
     def get_all_xsl_params(cls, output, obj, lang=None):
+        """
+        Get all XSLT params for a transform target.
+
+        This method should not be overridden. It calls `get_xsl_params` on all
+        subclasses of `XslProvider`, and it adds various common params that are
+        used across all of Pintail. The return value is a list of tuples, where
+        each tuple is a pair with the param name and the param value. The param
+        value is always a string.
+
+        The `output` parameter is a string specifying the output format. It is
+        usually `"html"`, but extensions could create other output formats.
+
+        The `obj` parameter is an object that a transform will be applied to.
+        It is usually an instance of a `Page` subclass, but it could be something
+        else. Always check `obj` before making assumptions.
+        """
         ret = []
         if output == 'html' and hasattr(obj, 'site'):
             html_extension = obj.site.config.get('html_extension') or '.html'
@@ -106,6 +189,7 @@ class XslProvider(Extendable):
             ret.extend(c.get_xsl_params(output, obj, lang))
         return ret
 
+
     @classmethod
     def get_xsltproc_args(cls, output, obj, lang=None):
         # Drop this function in the future if we decide to keep DocBook using
@@ -117,80 +201,246 @@ class XslProvider(Extendable):
 
 
 class Page(Extendable):
-    def __init__(self, directory, source_file):
-        self.directory = directory
-        self.site = directory.site
+    """
+    An individual page in a directory.
 
-        self._source_file = source_file
+    Each page belongs to one directory and comes from one source.
+    It is uniquely identified in the directory with the `page_id` parameter,
+    and it is uniquely identified in the site with the `site_id` parameter.
+
+    The page is the smallest addressable unit in a Pintail site.
+    There should be a `Page` object for each output page that you may
+    want to link to, translate, or have in the search index.
+    In some cases, a single source file creates multiple output pages.
+    In those cases, there should be a `Page` object for each output page,
+    even though all pages might be built in a single pass.
+
+    A `Page` object is responsible for building output, getting media files,
+    and extracting search data. It does this both for the original document
+    and for all translations.
+    """
+
+    def __init__(self, source, filename):
+        self.source = source
+        self.directory = source.directory
+        self.site = source.site
+
+        self._source_file = filename
         self._search_domains = None
+
 
     @property
     def page_id(self):
+        """
+        The simple id of the page.
+
+        This usually comes from either an id attribute or a base filename,
+        and it usually serves as the base filename of the target file.
+        Two pages in the same directory cannot have the same id.
+        """
         return None
+
 
     @property
     def site_id(self):
+        """
+        The fully qualified site id of the page.
+
+        The site id of a page is the path of the containing directory and the page id.
+        It must be unique across the entire site.
+        """
         return self.directory.path + self.page_id
+
 
     @property
     def site_path(self):
+        """
+        The full absolute path to the file in the site.
+
+        This is suitable for linking.
+        It includes the directory path as well as the site root.
+        It also includes the link extension.
+        """
         root = self.site.config.get_site_root(self.directory.path)
         ext = self.site.config.get('link_extension')
         if ext is None:
             ext = self.site.config.get('html_extension') or '.html'
         return root + self.site_id[1:] + ext
 
+
     @property
     def source_file(self):
+        """
+        The name of the source file for this page. 
+        """
         return self._source_file
 
+
     def get_source_path(self):
-        return os.path.join(self.directory.get_source_path(), self.source_file)
+        """
+        The absolute path to the source file for this page.
+        """
+        return os.path.join(self.source.get_source_path(), self.source_file)
+
 
     @property
     def stage_file(self):
+        """
+        The name of the staged file for this page.
+        """
         return self.source_file
 
+
     def get_stage_path(self, lang=None):
+        """
+        The absolute path to the staged file for this page.
+        """
         return os.path.join(self.directory.get_stage_path(lang), self.stage_file)
+
 
     @property
     def target_file(self):
+        """
+        The name of the target file for this page.
+        """
         return self.page_id + self.target_extension
 
+
     def get_target_path(self, lang=None):
+        """
+        The absolute path to the target file for this page.
+
+        This will often just be the directory's target path plus the target file name.
+        However, translation providers may modify the path in various ways.
+        """
         return self.site.get_page_target_path(self, lang)
+
 
     @property
     def target_extension(self):
+        """
+        The file extension for output files.
+        """
         return self.site.config.get('html_extension') or '.html'
+
 
     @property
     def searchable(self):
+        """
+        Whether the page should be added to the search index.
+
+        This is False by default for the base class,
+        but most page extensions should set this to True.
+        """
         return False
 
+
     def get_cache_data(self, lang=None):
+        """
+        Get XML data to add to the cache, as an lxml.etree.Element object.
+
+        For most page types, each page should provide information for the cache.
+        For formats that use a Mallard-like toolchain, this is usually a `page` element
+        containing only certain metadata and child elements.
+        For other formats, a `pintail:external` element can be used instead.
+
+        For information on Mallard cache files, see http://projectmallard.org/cache/1.1/
+        """
         return None
 
+
     def get_media(self):
+        """
+        Get a list of referenced media files.
+
+        Pages can return a list of images, videos, and other referenced media
+        so that it can be copied into the built site automatically. The return
+        value is a list of strings, where each string is a relative path. Media
+        files should exist in either the page's source or in the stage.
+        """
         return []
 
+
     def get_title(self, hint=None, lang=None):
+        """
+        Get the title of the page.
+
+        If the `lang` parameter is not `None`, get a translated title.
+        Otherwise, get the title in the source language.
+        The `hint` parameter is a string indicating where this title will be used.
+        For example, the `"search"` hint is used when the title is used in a search index.
+        """
         return ''
+
 
     def get_desc(self, hint=None, lang=None):
+        """
+        Get the desc of the page.
+
+        If the `lang` parameter is not `None`, get a translated desc.
+        Otherwise, get the desc in the source language.
+        The `hint` parameter is a string indicating where this desc will be used.
+        For example, the `"search"` hint is used when the desc is used in a search index.
+        """
         return ''
+
 
     def get_keywords(self, hint=None, lang=None):
+        """
+        Get the keywords of the page.
+
+        The return value should be a comma-separated list of keywords.
+        If the `lang` parameter is not `None`, get translated keywords.
+        Otherwise, get the keywords in the source language.
+        The `hint` parameter is a string indicating where these keywords will be used.
+        For example, the `"search"` hint is used when the keywords is used in a search index.
+        """
         return ''
+
 
     def get_content(self, hint=None, lang=None):
+        """
+        Get the full content of the page.
+
+        This is not expected to be formatted in a way that is pleasant to read.
+        It is mostly used for full-text search.
+        If the `lang` parameter is not `None`, get translated content.
+        Otherwise, get the content in the source language.
+        The `hint` parameter is a string indicating where this content will be used.
+        For example, the `"search"` hint is used when the content is used in a search index.
+        """
         return ''
 
+
     def build_html(self, lang=None):
+        """
+        Build the HTML file for this page, possibly translated.
+
+        Extensions should override this method to create the HTML output
+        from source or stage files. If the `lang` parameter is not `None`,
+        HTML should be built from the appropriate translated file.
+        """
         return
 
+
     def get_search_domains(self):
+        """
+        Get a list of search domains for the page.
+
+        Search domains allow you to restrict where search results come from.
+        Each page has its data added to each search domain in its list.
+        When a user starts a search from a page, it defaults to searching
+        in the page's first domain.
+
+        See the docstring on `Directory.get_search_domains` for more information
+        on how search domains work.
+
+        This method looks at the search domains returned by calling
+        `get_search_domains` on the containing `Directory` object.
+        It includes any domains in that list. For any page-domain mapping,
+        it includes just the domain, and only if the page ID matches.
+        The return value of this method is a list of strings only.
+        """
         if self._search_domains is not None:
             return self._search_domains
 
@@ -209,96 +459,178 @@ class Page(Extendable):
                 ret.append(dm)
         return ret
 
-    @classmethod
-    def get_pages(cls, directory, filename):
-        return []
 
     @classmethod
-    def get_pages_dir(cls, directory):
+    def create_pages(cls, source):
+        """
+        Create a list of `Page` objects for each page in a source.
+
+        This method should be overridden by extensions.
+        If this page extension recognizes any files in the source directory,
+        or can otherwise create pages for the directory, then it should return
+        a list of `Page` objects, one for each page it can provide. Note that
+        some formats might create multiple output pages from a single source
+        document. In these cases, one `Page` objecct should be created for
+        each output page, even if it shares a source file with other pages.
+        """
         return []
 
 
 class Directory(Extendable):
+    """
+    A directory in the built output.
+
+    Each directory contains one or more sources as `Source` objects.
+    For many simple sites, each directory will have one source.
+    However, Pintail can merge files from multiple sources into a directory.
+    Each directory also has a list of subdirectories and a list of pages.
+
+    The path of a directory represents where it goes in the build output,
+    as well as the portion of the URL after the site root.
+    We always start and end paths with a slash in Pintail.
+    The path also serves as the config key.
+    For simple sources, it's also where pages can be found in the source.
+    """
+
     def __init__(self, site, path, *, parent=None):
         self.site = site
         self.path = path
         self.parent = parent
-        self.directories = []
         self.pages = []
-
+        self.subdirs = []
+        self.sources = []
         self._search_domains = None
+        self.scan_directory()
 
-        self.read_directories()
-        self.read_pages()
 
     @property
     def translation_provider(self):
+        """
+        Get the translation provider for the directory.
+
+        Currently, this is just the translation provider for the entire site.
+        To allow per-directory translation providers in the future, any code
+        using translation providers should use this directory property
+        whenever possible.
+        """
         return self.site.translation_provider
 
-    def get_source_path(self):
-        if self.parent is not None:
-            return os.path.join(self.parent.get_source_path(), self.path.split('/')[-2])
-        else:
-            return os.path.join(self.site.topdir, self.path[1:])
 
     def get_stage_path(self, lang=None):
+        """
+        The absolute path to the directory for staged files in this directory.
+        """
         return os.path.join(self.site.get_stage_path(lang), self.path[1:])
 
+
     def get_target_path(self, lang=None):
+        """
+        The absolute path to the target directory.
+
+        This will often just be the site's target path plus the directory path.
+        However, translation providers may modify the path in various ways.
+        """
         return self.site.get_directory_target_path(self, lang)
 
-    @classmethod
-    def is_special_path(cls, site, path):
-        return False
 
-    def read_directories(self):
-        for name in os.listdir(self.get_source_path()):
-            if os.path.isdir(os.path.join(self.get_source_path(), name)):
-                subpath = self.path + name + '/'
-                if self.site.get_ignore_directory(subpath):
-                    continue
-                subdir = None
-                for cls in Directory.iter_subclasses():
-                    if cls.is_special_path(self.site, subpath):
-                        subdir = cls(self.site, subpath, parent=self)
-                        break
-                if subdir is None:
-                    subdir = Directory(self.site, subpath, parent=self)
-                self.directories.append(subdir)
+    def scan_directory(self):
+        """
+        Scan the directory for sources, subdirectories, and pages.
 
-    def read_pages(self):
+        This method is responsible for locating all sources for the directory,
+        checking those sources for subdirectories, asking all `Page` implementations
+        to provide pages for each source, and recursing into subdirectories.
+        It is called automatically by __init__.
+        """
+
+        # If we've scanned and found sources before, just exit
+        if len(self.sources) != 0:
+            return
+        # If the path corresponds to an actual on-disk directory,
+        # make a plain old source from that.
+        if os.path.isdir(os.path.join(self.site.srcdir, self.path[1:])):
+            self.sources.append(Source(self, self.path))
+        # Give each Source extension a chance to provide sources
+        # for this directory with this path.
+        for cls in Source.iter_subclasses('create_sources'):
+            self.sources.extend(cls.create_sources(self, self.path))
+        # Finally, if there are additional sources listed in the config,
+        # give each Source extension a chance to provide sources for
+        # each of those sources.
+        for source in (self.site.config.get('sources', self.path) or '').split():
+            for cls in Source.iter_subclasses('create_sources'):
+                self.sources.extend(cls.create_sources(self, source))
+
+        # Now that we have our sources, look for subdirectories of this
+        # directory, using all sources.
+        for source in self.sources:
+            for name in os.listdir(source.get_source_path()):
+                if os.path.isdir(os.path.join(source.get_source_path(), name)):
+                    subpath = self.path + name + '/'
+                    if self.site.get_ignore_directory(subpath):
+                        continue
+                    self.subdirs.append(Directory(self.site, subpath, parent=self))
+
+        # Finally, ask each Page extension to provide a list of pages for each source
         by_page_id = {}
-        for cls in Page.iter_subclasses('get_pages_dir'):
-            for page in cls.get_pages_dir(self):
-                if page.page_id in by_page_id:
-                    raise DuplicatePageException(self,
-                                                 'Duplicate page id ' +
-                                                 page.page_id)
-                by_page_id[page.page_id] = page
-                self.pages.append(page)
-        for name in os.listdir(self.get_source_path()):
-            if os.path.isfile(os.path.join(self.get_source_path(), name)):
-                for cls in Page.iter_subclasses('get_pages'):
-                    for page in cls.get_pages(self, name):
-                        if page.page_id in by_page_id:
-                            raise DuplicatePageException(self,
-                                                         'Duplicate page id ' +
-                                                         page.page_id)
-                        by_page_id[page.page_id] = page
-                        self.pages.append(page)
+        for source in self.sources:
+            for cls in Page.iter_subclasses('create_pages'):
+                for page in cls.create_pages(source):
+                    if page.page_id in by_page_id:
+                        raise DuplicatePageException(self,
+                                                     'Duplicate page id ' + page.page_id)
+                    by_page_id[page.page_id] = page
+                    self.pages.append(page)
+
 
     def iter_directories(self):
+        """
+        Iterate over this directory and all subdirectories at any depth.
+        """
         yield self
-        for subdir in self.directories:
+        for subdir in self.subdirs:
             yield from subdir.iter_directories()
 
+
     def iter_pages(self):
+        """
+        Iterate over all pages in this directory and all subdirectories at any depth.
+        """
         for page in self.pages:
             yield page
-        for subdir in self.directories:
+        for subdir in self.subdirs:
             yield from subdir.iter_pages()
 
+
     def get_search_domains(self):
+        """
+        Get a list of search domains for the directory.
+
+        Search domains allow you to restrict where search results come from.
+        Each page has its data added to each search domain in its list.
+        When a user starts a search from a page, it defaults to searching
+        in the page's first domain.
+
+        This method looks at the `search_domains` config option and returns
+        a list of search domains or page mappings for search domains.
+        Each component in the space-separated list could be a search domain,
+        a keyword for a search domain, or a mapping from a page ID to a domain.
+
+        Search domains look like directory paths. They always start with a slash.
+        For many directories, the search domain should just be that directory.
+        There's even a special keyword for that, `self`. There are four keywords:
+
+        * `self` - The current directory path.
+        * `parent` - The primary search domain of the parent directory.
+        * `global` - The top directory path, `/`.
+        * `none` - No search domain. Pages will not be indexed.
+
+        Components in the domain list can also be page mappings.
+        These are of the form `page_id:search_domain`. In these cases,
+        the value in the return list will be a list with the page ID and the domain.
+        The `get_search_domains` method on `Page` will only include the domains
+        that apply to that page.
+        """
         if self._search_domains is not None:
             return self._search_domains
 
@@ -334,14 +666,23 @@ class Directory(Extendable):
         self._search_domains = domains
         return self._search_domains
 
+
     def _maketargetdirs(self):
         Site._makedirs(self.get_target_path())
         if self.translation_provider is not None:
             for lc in self.translation_provider.get_directory_langs(self):
                 Site._makedirs(self.get_target_path(lc))
 
+
     def build_html(self):
-        for subdir in self.directories:
+        """
+        Build HTML files for pages in this directory and subdirectories.
+
+        This method calls `build_html` on each subdirectory and each page it contains.
+        It also queries the translation provider for translations,
+        and calls `build_html` on each page with those languages.
+        """
+        for subdir in self.subdirs:
             subdir.build_html()
         if not self.site.get_filter(self):
             return
@@ -354,51 +695,77 @@ class Directory(Extendable):
                 for lc in self.translation_provider.get_directory_langs(self):
                     page.build_html(lc)
 
+
     def build_media(self):
-        for subdir in self.directories:
+        """
+        Copy media files into the build directory.
+
+        Each page is expected to be able to provide a list of media files it references.
+        Media files could be images or videos, but they could also be any additional files.
+        This method looks at all pages in the directory for media files,
+        then attempts to copy each of those files into the target directory.
+        It looks in both the source trees and the stage,
+        so built media files in the stage will be handled here.
+        This method also recurses into subdirectories.
+        """
+        for subdir in self.subdirs:
             subdir.build_media()
         if not self.site.get_filter(self):
             return
         self._maketargetdirs()
-        media = set()
+        media = {}
         for page in self.pages:
             if not self.site.get_filter(page):
                 continue
-            media.update(page.get_media())
+            # If two pages from different sources provide the file,
+            # right now it's completely random which one will win.
+            for filename in page.get_media():
+                media[filename] = page.source
         for fname in media:
+            source = media[fname]
             langs = [None]
             if self.translation_provider is not None:
                 langs += self.translation_provider.get_directory_langs(self)
             for lc in langs:
                 if lc is not None:
-                    tr = self.translation_provider.translate_media(self, fname, lc)
+                    tr = self.translation_provider.translate_media(source, fname, lc)
                     if not tr:
                         continue
                     if fname.startswith('/'):
                         # These have to be managed with extra_files for now
                         continue
-                    source = os.path.join(self.get_stage_path(lc), fname)
+                    mediasrc = os.path.join(self.get_stage_path(lc), fname)
                     self.site.log('MEDIA', lc + ' ' + self.path + fname)
                 else:
                     if fname.startswith('/'):
-                        source = os.path.join(self.site.topdir, fname[1:])
+                        mediasrc = os.path.join(self.site.topdir, fname[1:])
                     else:
                         # The file might be generated, in which case it's in the
                         # stage directory. But we don't stage static media files,
                         # so those are just in the source directory.
-                        source = os.path.join(self.get_stage_path(), fname)
-                        if not os.path.exists(source):
-                            source = os.path.join(self.get_source_path(), fname)
+                        mediasrc = os.path.join(self.get_stage_path(), fname)
+                        if not os.path.exists(mediasrc):
+                            mediasrc = os.path.join(source.get_source_path(), fname)
                     self.site.log('MEDIA', self.path + fname)
                 target = self.site.get_media_target_path(self, fname, lc)
                 Site._makedirs(os.path.dirname(target))
                 try:
-                    shutil.copyfile(source, target)
+                    shutil.copyfile(mediasrc, target)
                 except:
                     self.site.logger.warn('Could not copy file %s' % fname)
 
+
     def build_files(self):
-        for subdir in self.directories:
+        """
+        Copy extra files into the build directory.
+
+        This method looks at the `extra_files` config option for
+        additional files that can't be found automatically.
+        It treats `extra_files` as a space-separated list of globs.
+        Each glob is checked against each source in the directory.
+        This method also recurses into subdirectories.
+        """
+        for subdir in self.subdirs:
             subdir.build_files()
         if not self.site.get_filter(self):
             return
@@ -406,18 +773,27 @@ class Directory(Extendable):
         globs = self.site.config.get('extra_files', self.path)
         if globs is not None:
             for glb in globs.split():
-                # This won't do what it should if the path has anything
-                # glob-like in it. Would be nice if glob() could take
-                # a base path that isn't glob-interpreted.
-                files = glob.glob(os.path.join(self.get_source_path(), glb))
-                for fname in files:
-                    self.site.log('FILE', self.path + os.path.basename(fname))
-                    shutil.copyfile(fname,
-                                    os.path.join(self.get_target_path(),
-                                                 os.path.basename(fname)))
+                for source in self.sources:
+                    # This won't do what it should if the path has anything
+                    # glob-like in it. Would be nice if glob() could take
+                    # a base path that isn't glob-interpreted.
+                    files = glob.glob(os.path.join(source.get_source_path(), glb))
+                    for fname in files:
+                        self.site.log('FILE', self.path + os.path.basename(fname))
+                        shutil.copyfile(fname,
+                                        os.path.join(self.get_target_path(),
+                                                     os.path.basename(fname)))
+
 
     def build_feeds(self):
-        for subdir in self.directories:
+        """
+        Build Atom feeds for this directory.
+
+        If the directory lists a file name in the `feed_atom` config option,
+        then this method creates an Atom feed from the pages in the directory.
+        This method also recurses into subdirectories.
+        """
+        for subdir in self.subdirs:
             subdir.build_feeds()
         if not self.site.get_filter(self):
             return
@@ -472,18 +848,53 @@ class Directory(Extendable):
                              atomxsl, self.site.get_cache_path()])
 
 
+class Source(Extendable):
+    """
+    A directory in the source.
 
-class EmptyDirectory(Directory):
-    def read_directories(self):
-        pass
+    A source represents a source of pages or other files.
+    It could be in the actual source tree, in another repository, or entirely virtual.
+    Each source belongs to exactly one `Directory` object for the output directory.
+    Although it's possible that some on-disk location provides pages for multiple output directories,
+    in that case there would be multiple `Source` objects for that location.
 
-    def read_pages(self):
-        pass
+    The name of a source is the config key group that defines it.
+    For simple sources, this will be the same as the path of the directory it belongs to.
+    For other sources, it could be an identifier that doesn't look like a path.
+    """
+    def __init__(self, directory, name):
+        self.directory = directory
+        self.name = name
+        self.site = self.directory.site
+
+
+    def get_source_path(self):
+        """
+        The absolute path to the source directory for this source.
+        """
+        return os.path.join(self.site.topdir, self.directory.path[1:])
+
+
+    @classmethod
+    def create_sources(cls, directory, name):
+        """
+        Return a list of source objects for a directory and source name.
+
+        This method should be overridden by extensions.
+        If this source extension recognizes something special in the directory,
+        or in the config keys under the group specified by the name parameter,
+        then it should return a (probably singleton) list of sources.
+        """
+        return []
 
 
 class Site:
+    """
+    Base class for an entire Pintail site.
+    """
     def __init__(self, config):
         self.topdir = os.path.dirname(config)
+        self.srcdir = self.topdir
         self.pindir = os.path.join(self.topdir, '__pintail__')
         self.target_path = os.path.join(self.pindir, 'build')
         self.tools_path = os.path.join(self.pindir, 'tools')
@@ -520,8 +931,17 @@ class Site:
             transcls = getattr(transmod, trans[dot+1:])
             self.translation_provider = transcls(self)
 
+
     @classmethod
     def init_site(cls, directory):
+        """
+        Initialize a new site with `pintail init`.
+
+        This is the method called by `pintail init` to create a new site.
+        FIXME: Want to contribute with some low-hanging fruit?
+        Make this ship sample XSLT and CSS files, and put `custom_xsl` and
+        `custom_css` options in the sample `pintail.cfg`.
+        """
         cfgfile = os.path.join(directory, 'pintail.cfg')
         if os.path.exists(cfgfile):
             sys.stderr.write('pintail.cfg file already exists\n')
@@ -532,7 +952,14 @@ class Site:
         fd.write(codecs.decode(sample, 'utf-8'))
         fd.close()
 
+
     def set_filter(self, dirs):
+        """
+        Set a filter for which pages will be built.
+
+        This can be passed to `pintail build` on the command line to build a partial site.
+        If the filter ends with a slash, it is a directory. Otherwise, it is a page.
+        """
         self._filter = []
         if dirs is None:
             return
@@ -541,7 +968,13 @@ class Site:
                 fdir = '/' + fdir
             self._filter.append(fdir)
 
+
     def get_filter(self, obj):
+        """
+        Get whether or not an object meets the filter.
+
+        The object `obj` could be a page or a directory.
+        """
         if len(self._filter) == 0:
             return True
         if isinstance(obj, Directory):
@@ -562,7 +995,15 @@ class Site:
                         return True
         return False
 
+
     def get_custom_xsl(self):
+        """
+        Get all custom XSLT files.
+
+        This returns a list of custom XSLT files that should be included in any
+        top-level XSLT files. It includes any files specified in the `custom_xsl`
+        config option, as well as any files provided by any loaded `XslProvider`.
+        """
         ret = []
         custom_xsl = self.config.get('custom_xsl') or ''
         for x in custom_xsl.split():
@@ -571,39 +1012,73 @@ class Site:
             ret.extend(cls.get_xsl(self))
         return ret
 
+
     def get_langs(self):
+        """
+        Get all languages used throughout the site.
+
+        If there is a translation provider, this method calls `get_site_langs`
+        on that provider. Otherwise, it returns an empty list.
+        """
         if self.translation_provider is not None:
             return self.translation_provider.get_site_langs()
         return []
 
+
     def get_source_lang(self):
+        """
+        Get the language code for the original source language of the site.
+
+        If there is a translation provider, this method calls `get_source_lang`
+        on that provider. Otherwise, it returns `en` as a default.
+        """
         if self.translation_provider is not None:
             return self.translation_provider.get_source_lang()
         return 'en'
 
+
     def get_stage_path(self, lang=None):
+        """
+        The absolute path to the directory for staged files for this site.
+        """
         if lang is not None:
             return os.path.join(self.pindir, 'stage-' + lang)
         else:
             return os.path.join(self.pindir, 'stage')
 
+
     def get_cache_path(self, lang=None):
+        """
+        The absolute path to the Mallard cache file for the site in the language.
+        """
         if lang is not None:
             return os.path.join(self.tools_path, 'pintail-' + lang + '.cache')
         else:
             return os.path.join(self.tools_path, 'pintail.cache')
 
+
     def get_directory_target_path(self, directory, lang=None):
+        """
+        The absolute path to where the built files for a directory should go.
+        """
         return os.path.join(self.target_path, directory.path[1:])
 
+
     def get_page_target_path(self, page, lang=None):
+        """
+        The absolute path to where the built file for a page should go.
+        """
         dirpath = self.get_directory_target_path(page.directory)
         if lang is None:
             return os.path.join(dirpath, page.target_file)
         else:
             return os.path.join(dirpath, page.target_file + '.' + lang)
 
+
     def get_media_target_path(self, directory, mediafile, lang=None):
+        """
+        The absolute path to where a media file should go in the built directory.
+        """
         if lang is not None:
             langext = '.' + lang
         else:
@@ -613,14 +1088,36 @@ class Site:
         else:
             return os.path.join(directory.get_target_path(), mediafile + langext)
 
+
     def translate_page(self, page, lang):
+        """
+        Translate a page into a language and return whether it was translated.
+
+        If there is no translation provider, this method just returns `False`.
+        Otherwise, it first checks to see if the translated file already exists,
+        and if it doesn't, it calls `translate_page` on the translation provider.
+        """
         if self.translation_provider is not None:
             if not self.get_filter(page):
                 if os.path.exists(page.get_stage_path(lang)):
                     return True
             return page.directory.translation_provider.translate_page(page, lang)
+        return False
 
-    def read_directories(self):
+
+    def scan_site(self):
+        """
+        Scan the entire site for directories, sources, and pages.
+
+        This method is responsible for finding all directories, sources, and pages
+        throughout the entire site. Most of the work is done by `Directory.scan_directory`.
+        This method starts by creating a root directory, which is able to find subdirectories.
+        It then looks at special directories defined in the config file, and creates
+        directories and parents as necessary for those.
+
+        This method is not called automatically. Ensure you call it before any build methods.
+        It is safe to call this method multiple times.
+        """
         if self.root is not None:
             return
         if os.path.exists(self.get_stage_path()):
@@ -630,38 +1127,28 @@ class Site:
         for directory in self.root.iter_directories():
             directories[directory.path] = directory
 
-        configdirs = sorted(self.config.get_directories(), key=len)
+        configdirs = [d for d in self.config._config.sections()
+                      if d.startswith('/') and d.endswith('/')]
         for path in configdirs:
             if path not in directories:
-                directory = None
-                for cls in Directory.iter_subclasses():
-                    if cls.is_special_path(self, path):
-                        directory = cls(self, path)
-                        break
-                if directory is None:
-                    directory = EmptyDirectory(self, path)
-                directories[path] = directory
+                parent = directories['/']
+                curpath = '/'
+                for curpart in path[1:-1].split('/'):
+                    curpath = curpath + curpart + '/'
+                    if curpath in directories:
+                        parent = directories[curpath]
+                    else:
+                        curdir = Directory(self, curpath, parent=parent)
+                        parent.subdirs.append(curdir)
+                        directories[curpath] = curdir
+                        parent = curdir
 
-                parentpath = '/'.join(path.split('/')[:-2]) + '/'
-                if parentpath in directories:
-                    directories[parentpath].directories.append(directory)
-                    if directory.parent is None:
-                        directory.parent = directories[parentpath]
-                else:
-                    while parentpath not in directories:
-                        parentdir = EmptyDirectory(self, parentpath)
-                        parentdir.directories.append(directory)
-                        if directory.parent is None:
-                            directory.parent = parentdir
-                        directories[parentpath] = parentdir
-                        directory = parentdir
-                        parentpath = '/'.join(parentpath.split('/')[:-2]) + '/'
-                    directories[parentpath].directories.append(directory)
-                    if directory.parent is None:
-                        directory.parent = directories[parentpath]
 
     def build(self):
-        self.read_directories()
+        """
+        Build the entire site, including all pages and additional files.
+        """
+        self.scan_site()
         self.build_cache()
         self.build_tools()
         self.build_html()
@@ -673,8 +1160,12 @@ class Site:
             self.build_css()
             self.build_js()
 
+
     def build_cache(self):
-        self.read_directories()
+        """
+        Build the Mallard cache files for this site.
+        """
+        self.scan_site()
         self.log('CACHE', self.get_cache_path())
         cache = etree.Element(CACHE_NS + 'cache', nsmap={
             None: 'http://projectmallard.org/1.0/',
@@ -704,7 +1195,15 @@ class Site:
             cache.getroottree().write(self.get_cache_path(lang),
                                       pretty_print=True)
 
+
     def build_tools(self):
+        """
+        Build all the tools necessary to build the site.
+
+        This method grabs and builds the latest version of yelp-xsl,
+        then copies its customizations into `pintail-html.xsl`,
+        and finally calls `get_tools` on each `ToolsProvider`.
+        """
         Site._makedirs(self.tools_path)
         if os.path.exists(self.yelp_xsl_path):
             if self.config._update:
@@ -747,22 +1246,39 @@ class Site:
         for cls in ToolsProvider.iter_subclasses('build_tools'):
             cls.build_tools(self)
 
+
     def build_html(self):
-        self.read_directories()
+        """
+        Build all HTML files for this site.
+        """
+        self.scan_site()
         self.root.build_html()
 
+
     def build_media(self):
-        self.read_directories()
+        """
+        Copy media files for the entire site.
+        """
+        self.scan_site()
         self.root.build_media()
 
-    def build_css(self):
-        self.read_directories()
 
+    def build_css(self):
+        """
+        Build all of the CSS for the site.
+
+        This function iterates over all `CssProvider` subclasses and asks them to build CSS.
+        """
+        self.scan_site()
         for cls in CssProvider.iter_subclasses('build_css'):
             cls.build_css(self)
 
+
     def build_js(self):
-        self.read_directories()
+        """
+        Build all JavaScript files for the site.
+        """
+        self.scan_site()
         jspath = os.path.join(self.yelp_xsl_path, 'js')
 
         if os.path.exists(os.path.join(jspath, 'jquery.js')):
@@ -862,32 +1378,64 @@ class Site:
                 shutil.copyfile(os.path.join(jspath, brush),
                                 os.path.join(self.target_path, brush))
 
+
     def build_files(self):
-        self.read_directories()
+        """
+        Copy all extra files for this site.
+        """
+        self.scan_site()
         self.root.build_files()
 
+
     def build_feeds(self):
-        self.read_directories()
+        """
+        Build all Atom feeds for this site.
+        """
+        self.scan_site()
         self.root.build_feeds()
 
+
     def build_search(self):
+        """
+        Build all search data for the site.
+
+        If there is a search provider, this method calls `index_site` on it.
+        Otherwise, this method does nothing.
+        """
         if self.config._index:
-            self.read_directories()
+            self.scan_site()
             if self.search_provider is not None:
                 self.search_provider.index_site()
 
-    def get_ignore_directory(self, directory):
-        if directory == '/__pintail__/':
+
+    def get_ignore_directory(self, path):
+        """
+        Get whether or not to ignore a directory path when scanning a site.
+
+        The `path` argument is a path as used by `Directory`.
+        If it should be ignored, this method returns `True`.
+        Currently, we ignore Pintail's built directory and git's hidden directory.
+        We should be smarter in the future, and perhaps allow a config option.
+        """
+        if path == '/__pintail__/':
             return True
         # FIXME: use an ignore key in config
-        if directory == '/.git/':
+        if path == '/.git/':
             return True
         return False
 
+
     def log(self, tag, data):
+        """
+        Write something to the log.
+
+        Pintail uses a tag to indicate what kind of thing is happening,
+        followed by a data string to show what that thing is happening to.
+        """
         if data.startswith(self.pindir + '/'):
             data = data[len(os.path.dirname(self.pindir))+1:]
         self.logger.info('%(tag)-6s %(data)s' % {'tag': tag, 'data': data})
+
 
     @classmethod
     def _makedirs(cls, path):
@@ -902,6 +1450,13 @@ class Site:
 
 
 class Config:
+    """
+    The configuration for a site.
+
+    This class wraps Python's `ConfigParser` with various utility methods
+    to ensure consistent access across Pintail.
+    """
+
     def __init__(self, site, filename):
         self._site = site
         self._config = configparser.ConfigParser()
@@ -910,7 +1465,16 @@ class Config:
         self._update = True
         self._index = True
 
+
     def get(self, key, path=None):
+        """
+        Get the value for a key, possibly in a path.
+
+        If `path` is omitted, it's assumed to be `pintail`, which is the group
+        in the config file where site-level options are defined. If the path is
+        `pintail` and `--local` has been passed to the `pintail` command, this
+        method will also look in the `local` config group for overrides.
+        """
         if path is None:
             path = 'pintail'
         if self._local and path == 'pintail':
@@ -919,7 +1483,14 @@ class Config:
                 return ret
         return self._config.get(path, key, fallback=None)
 
+
     def get_site_root(self, path=None):
+        """
+        Get the root path for the site.
+
+        For normal builds, this is either `"/"` or the value of the `site_root` config option.
+        For local builds, this method creates a relative path from the `path` argument.
+        """
         if self._local and path is not None:
             if path == '/':
                 return './'
@@ -930,17 +1501,32 @@ class Config:
         else:
             return self.get('site_root') or '/'
 
+
     def set_local(self):
+        """
+        Set whether we are doing a local build.
+
+        Local builds modify paths and certain other things to create files
+        suitable for previewing locally.
+        """
         self._config.set('pintail', 'site_root',
                          self._site.target_path + '/')
         self._local = True
 
+
     def set_update(self, update):
+        """
+        Set whether or not git repositories should be updated.
+
+        Pintail will always clone repositories it does not have yet.
+        Normally, it will update repositories it has already cloned.
+        With updates turned off, it will not update cloned repositories.
+        """
         self._update = update
 
-    def set_index(self, index):
-        self._index = index
 
-    def get_directories(self):
-        return [d for d in self._config.sections()
-                if d.startswith('/') and d.endswith('/')]
+    def set_index(self, index):
+        """
+        Set whether or not to index pages with the search provider.
+        """
+        self._index = index

--- a/pintail/translation.py
+++ b/pintail/translation.py
@@ -1,5 +1,5 @@
 # pintail - Build static sites from collections of Mallard documents
-# Copyright (c) 2016 Shaun McCance <shaunm@gnome.org>
+# Copyright (c) 2016-2020 Shaun McCance <shaunm@gnome.org>
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -19,14 +19,31 @@
 import pintail.site
 
 class TranslationProvider(pintail.site.Extendable):
+    """
+    An extension point to provide translations for the site.
+    """
     def __init__(self, site):
         self.site = site
         self._langs = None
 
+
     def get_source_lang(self):
+        """
+        Get the language code for the original source language of the site.
+
+        By default, this uses the `source_lang` config option, or `en` if that isn't present.
+        Different translation providers could have a different behavior.
+        """
         return self.site.config.get('source_lang') or 'en'
 
+
     def get_site_langs(self):
+        """
+        Get all languages used throughout the site.
+
+        This returns all languages used in any directory in the site.
+        Translation providers probably do not need to override this method.
+        """
         if self._langs is not None:
             return self._langs
         self._langs = []
@@ -36,11 +53,29 @@ class TranslationProvider(pintail.site.Extendable):
                     self._langs.append(lang)
         return self._langs
 
+
     def get_directory_langs(self, directory):
+        """
+        Get all languages available for a single directory.
+
+        Translation providers should override this method.
+        """
         return []
 
+
     def translate_page(self, page, lang):
+        """
+        Translate a page into a language and return whether it was translated.
+
+        Translation providers should override this method.
+        """
         return False
 
-    def translate_media(self, directory, mediafile, lang):
+
+    def translate_media(self, source, mediafile, lang):
+        """
+        Translate a media file into a language and return whether it was translated.
+
+        Translation providers should override this method.
+        """
         return False


### PR DESCRIPTION
This is a fairly sizable refactor to allow multiple sources to be used for a single directory. For example, to merge the pages from gnome-getting-started-docs into gnome-help. It will require changes in pintail-itstool and pintail-asciidoc.

I've tested this pretty thoroughly, but I wouldn't mind a sanity check. @amigadave?